### PR TITLE
添加查找项目或包的根目录的功能

### DIFF
--- a/lib/path.js
+++ b/lib/path.js
@@ -45,7 +45,8 @@ exports.getRootDirectory = function (cwd) {
     // 出于这个问题，项目根目录找的是最近的那个目录，而包的根目录找的是最远的那个
     var projectRoot = path.resolve(cwd || process.cwd());
     var packageRoot = null;
-    while (projectRoot !== '/') {
+    var systemRoot = path.resolve('/');
+    while (projectRoot !== systemRoot) {
         // 如果是项目根就直接返回，不用再找了
         if (fs.existsSync(path.join(projectRoot, '.edpproj'))) {
             return projectRoot;


### PR DESCRIPTION
不少模块会需要读取根目录下的`edp-xxx-config.js`文件，或者类似`.jshintrc`的配置文件，因此这个功能放在这里相比`edp-project`更合适
