### PR TITLE
add: edp exit mechanism

### DIFF
--- a/lib/log.js
+++ b/lib/log.js
@@ -54,6 +54,9 @@ fns.forEach(function (item) {
         else {
             console.log();
         }
+        if (process.env.EDP_EXIT_LOG_LEVEL && process.env.EDP_EXIT_LOG_LEVEL - item.level <= 0) {
+            process.exit(1);
+        }
     };
 });
 


### PR DESCRIPTION
当 edp build 出错的时候，比如说 fatal error，这种情况下应通知上层调用方再做其他处理。

目前 edp build 默默的吃下了 log warn error fatal 等信息。